### PR TITLE
Smart copy-paste annotation feature

### DIFF
--- a/src/components/viewer/DrawTools.vue
+++ b/src/components/viewer/DrawTools.vue
@@ -598,12 +598,12 @@ export default {
         this.$store.commit(this.viewerModule + 'setCopiedAnnot', annot);
       }
     },
-    copiedAnnotImageIndex: {
+    copiedAnnotImageInstance: {
       get() {
-        return this.viewerWrapper.copiedAnnotImageIndex;
+        return this.viewerWrapper.copiedAnnotImageInstance;
       },
-      set(index) {
-        this.$store.commit(this.viewerModule + 'setCopiedAnnotImageIndex', index);
+      set(image) {
+        this.$store.commit(this.viewerModule + 'setCopiedAnnotImageInstance', image);
       }
     },
     linkableCopiedAnnot() {
@@ -788,7 +788,7 @@ export default {
         return;
       }
 
-      this.copiedAnnotImageIndex = this.index;
+      this.copiedAnnotImageInstance = this.image;
       this.copiedAnnot = feature.properties.annot.clone();
       this.$notify({type: 'success', text: this.$t('notif-success-annotation-copy')});
     },
@@ -808,7 +808,7 @@ export default {
       /* Compute the rescaling factors if the resolution is known for both images */
       let scaleX = 1;
       let scaleY = 1;
-      let srcImage = this.viewerWrapper.images[this.copiedAnnotImageIndex].imageInstance;
+      let srcImage = this.copiedAnnotImageInstance;
       let hasPhysicalSizeX = srcImage.physicalSizeX !== null && destImage.physicalSizeX !== null;
       let hasPhysicalSizeY = srcImage.physicalSizeY !== null && destImage.physicalSizeY !== null;
 

--- a/src/components/viewer/DrawTools.vue
+++ b/src/components/viewer/DrawTools.vue
@@ -432,7 +432,7 @@ import AnnotationLinkSelector from '@/components/viewer/interactions/AnnotationL
 import WKT from 'ol/format/WKT';
 import {containsExtent, getCenter, getIntersection} from 'ol/extent';
 
-import {Cytomine, Annotation, AnnotationType, AnnotationLink, ImageInstance} from 'cytomine-client';
+import {Cytomine, Annotation, AnnotationType, AnnotationLink} from 'cytomine-client';
 import {
   Action, updateTermProperties, updateTrackProperties, updateAnnotationLinkProperties,
   listAnnotationsInGroup
@@ -596,6 +596,14 @@ export default {
       },
       set(annot) {
         this.$store.commit(this.viewerModule + 'setCopiedAnnot', annot);
+      }
+    },
+    copiedAnnotImageIndex: {
+      get() {
+        return this.viewerWrapper.copiedAnnotImageIndex;
+      },
+      set(index) {
+        this.$store.commit(this.viewerModule + 'setCopiedAnnotImageIndex', index);
       }
     },
     linkableCopiedAnnot() {
@@ -780,10 +788,11 @@ export default {
         return;
       }
 
+      this.copiedAnnotImageIndex = this.index;
       this.copiedAnnot = feature.properties.annot.clone();
       this.$notify({type: 'success', text: this.$t('notif-success-annotation-copy')});
     },
-    async convertLocation(copiedAnnot, destImage) {
+    convertLocation(copiedAnnot, destImage) {
       /* If we want to paste in the same image but in another slice */
       if (destImage.id === copiedAnnot.image) {
         return copiedAnnot.location;
@@ -791,7 +800,7 @@ export default {
 
       /* Compute the rescaling factor if the resolution is known for both images */
       let scale = 1;
-      let srcImage = await ImageInstance.fetch(copiedAnnot.image);
+      let srcImage = this.viewerWrapper.images[this.copiedAnnotImageIndex].imageInstance;
       if (srcImage.physicalSizeX !== null && destImage.physicalSizeX !== null) {
         scale = srcImage.physicalSizeX / destImage.physicalSizeX;
       }
@@ -838,7 +847,7 @@ export default {
       }
 
       /* Convert the location if it is needed */
-      let location = await this.convertLocation(this.copiedAnnot, this.image);
+      let location = this.convertLocation(this.copiedAnnot, this.image);
       if (!location) {
         this.$notify({type: 'error', text: this.$t('notif-error-annotation-paste')});
         return;

--- a/src/components/viewer/DrawTools.vue
+++ b/src/components/viewer/DrawTools.vue
@@ -804,6 +804,15 @@ export default {
       geometry.translate(wrapper.view.center[0] - centerExtent[0], wrapper.view.center[1] - centerExtent[1]);
       geometry.scale(scale);
 
+      /* Rescale the annotation if it is larger than the destination image size */
+      let annotExtent = geometry.getExtent();
+      let annotWidth = annotExtent[2] - annotExtent[0];
+      let annotHeight = annotExtent[3] - annotExtent[1];
+      if (annotWidth > destImage.width || annotHeight > destImage.height) {
+        scale = annotHeight > annotWidth ? annotWidth / annotHeight : annotHeight / annotWidth;
+        geometry.scale(scale);
+      }
+
       /* Check if the translation is within the image boundaries */
       let imageExtent = [0, 0, destImage.width, destImage.height];
       if (!containsExtent(imageExtent, geometry.getExtent())) {

--- a/src/store/modules/project_modules/viewer.js
+++ b/src/store/modules/project_modules/viewer.js
@@ -30,7 +30,7 @@ export default {
       indexNextImage: 0,
 
       copiedAnnot: null,
-      copiedAnnotImageIndex: null
+      copiedAnnotImageInstance: null
     };
   },
 

--- a/src/store/modules/project_modules/viewer.js
+++ b/src/store/modules/project_modules/viewer.js
@@ -29,7 +29,8 @@ export default {
       activeImage: 0,
       indexNextImage: 0,
 
-      copiedAnnot: null
+      copiedAnnot: null,
+      copiedAnnotImageIndex: null
     };
   },
 
@@ -50,6 +51,10 @@ export default {
 
     setCopiedAnnot(state, annot) {
       state.copiedAnnot = annot;
+    },
+
+    setCopiedAnnotImageIndex(state, index) {
+      state.copiedAnnotImageIndex = index;
     },
 
     setLinkMode(state, mode) {

--- a/src/store/modules/project_modules/viewer.js
+++ b/src/store/modules/project_modules/viewer.js
@@ -53,8 +53,8 @@ export default {
       state.copiedAnnot = annot;
     },
 
-    setCopiedAnnotImageIndex(state, index) {
-      state.copiedAnnotImageIndex = index;
+    setCopiedAnnotImageInstance(state, image) {
+      state.copiedAnnotImageInstance = image;
     },
 
     setLinkMode(state, mode) {


### PR DESCRIPTION
Implemented feature of a smart copy-paste:

- When the resolution of the both images (the image where the annotation is copied and the image where the annotation is pasted) is known, rescale the annotation according to the resolution of the destination image.
- When the resolution of the either one or both images is **not** known, make an approximate rescaling to fit within the bounds of the destination image