### PR TITLE
Fix link tab length display

### DIFF
--- a/src/components/viewer/panels/LinkPanel.vue
+++ b/src/components/viewer/panels/LinkPanel.vue
@@ -24,18 +24,6 @@
     </b-select>
   </b-field>
 
-  <div class="current-group" v-if="linkedIndexes">
-    <p>{{$t('view-linked-with')}}</p>
-    <ul>
-      <li v-for="index in linkedIndexes" :key="index">
-        <i class="fas fa-caret-right"></i>
-          {{$t('viewer-view', {number: imagesWithNum[index].number})}}
-          (<image-name :image="imagesWithNum[index].image" />) <br/>
-      </li>
-    </ul>
-    <button class="button is-small" @click="unlink()">{{$t('button-unlink')}}</button>
-  </div>
-
   <template>
     <table class="table">
       <thead>
@@ -45,6 +33,17 @@
       </tr>
       </thead>
       <tbody>
+      <!-- Display linked images -->
+      <tr v-for="index in linkedIndexes" :key="index">
+        <td>
+          <b-checkbox :value="true" @input="unlink"/>
+        </td>
+        <td>
+          {{$t('viewer-view', {number: imagesWithNum[index].number})}}
+          (<image-name :image="imagesWithNum[index].image" />)
+        </td>
+      </tr>
+
       <!-- Display other groups to linked with -->
       <tr v-for="{images, index, number} in otherGroups" :key="`group${number}`">
         <td>
@@ -181,7 +180,6 @@ export default {
           confirmText: this.$t('button-confirm'),
           cancelText: this.$t('button-cancel'),
           onConfirm: () => {
-            event.target.checked = false; // reset state of checkbox
             this.$store.commit(this.imageModule + 'setTrackedUser', null);
             this.link(indexGroup, indexImage);
           },
@@ -189,7 +187,6 @@ export default {
         });
       }
       else {
-        event.target.checked = false; // reset state of checkbox
         this.link(indexGroup, indexImage);
       }
     },

--- a/src/components/viewer/panels/LinkPanel.vue
+++ b/src/components/viewer/panels/LinkPanel.vue
@@ -36,27 +36,45 @@
     <button class="button is-small" @click="unlink()">{{$t('button-unlink')}}</button>
   </div>
 
-  <template v-if="otherGroups.length || otherSoloImages.length">
-    <p v-if="linkedIndexes">{{$t('link-other-images-to-this-group')}}</p>
-    <p v-else>{{$t('link-view-with')}}</p>
-    <p v-for="{images, index, number} in otherGroups" :key="`group${number}`">
-      <b-checkbox :value="false" @change.native="event => handleCheckboxChange(event, index)">
-        {{$t('link-group', {number})}}
-        <ul class="group">
-          <li v-for="indexImage in images" :key="indexImage">
-            <i class="fas fa-caret-right"></i>
-            {{$t('viewer-view', {number: imagesWithNum[indexImage].number})}}
-            (<image-name :image="imagesWithNum[indexImage].image" />) <br/>
-          </li>
-        </ul>
-      </b-checkbox>
-    </p>
-    <p v-for="{image, index, number} in otherSoloImages" :key="index">
-      <b-checkbox :value="false" @change.native="event => handleCheckboxChange(event, null, index)">
-        {{$t('viewer-view', {number})}} (<image-name :image="image" />)
-      </b-checkbox>
-    </p>
+  <template>
+    <table class="table">
+      <thead>
+      <tr>
+        <th><span class="fas fa-link"></span></th>
+        <th> {{ $t('link-view-with') }}</th>
+      </tr>
+      </thead>
+      <tbody>
+      <!-- Display other groups to linked with -->
+      <tr v-for="{images, index, number} in otherGroups" :key="`group${number}`">
+        <td>
+          <b-checkbox :value="false" @change.native="event => handleCheckboxChange(event, index)"/>
+        </td>
+        <td>
+          {{$t('link-group', {number})}}
+          <ul class="group">
+            <li v-for="indexImage in images" :key="indexImage">
+              <i class="fas fa-caret-right"></i>
+              {{$t('viewer-view', {number: imagesWithNum[indexImage].number})}}
+              (<image-name :image="imagesWithNum[indexImage].image" />) <br/>
+            </li>
+          </ul>
+        </td>
+      </tr>
+
+      <!-- Display unlinked images -->
+      <tr v-for="{image, index, number} in otherSoloImages" :key="index">
+        <td>
+          <b-checkbox :value="false" @change.native="event => handleCheckboxChange(event, null, index)"/>
+        </td>
+        <td>
+          {{$t('viewer-view', {number})}} (<image-name :image="image" />)
+        </td>
+      </tr>
+      </tbody>
+    </table>
   </template>
+
 </div>
 </template>
 
@@ -223,5 +241,21 @@ ul.group {
 /deep/ .b-checkbox {
   align-items: flex-start !important;
   margin-top: 0.25em;
+}
+
+.table {
+  margin-bottom: 1em !important;
+  font-size: 0.9em;
+}
+
+.table tbody {
+  display: block;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  max-height: 10em;
+}
+
+.table thead tr {
+  display: block;
 }
 </style>

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -266,11 +266,8 @@ button-reset,Reset,Réinitialiser
 select-image-to-add,Select an image to add,Sélectionner une image à ajouter
 link-images,Link images,Synchronisation d'images
 link-view-with,Link this view with...,Synchroniser cette image avec...
-link-other-images-to-this-group,Link this group with additional images...,Synchroniser ce groupe avec d'autres images...
-view-linked-with,This view is linked with,Cette image est synchronisée avec :
 viewer-view,View {number},Image {number}
 link-group,Group {number},Groupe {number}
-button-unlink,Unlink,Séparer
 terms-new-annotation,Term(s) to associate to new annotations,Terme(s) à associer aux nouvelles annotations
 core-cannot-be-reached,Error of communication with Cytomine core,Erreur de communication avec le backend de Cytomine
 communication-error,Communication error,Erreur de communication


### PR DESCRIPTION
This PR refactor the link panel to fix the bug that occurred when there is numerous images to link (more than 8 images).
It closes #7 